### PR TITLE
more general way to specify that an array-like object should be treated as a scalar by lazyarray

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -261,5 +261,5 @@ epub_copyright = u'2012-2020, Andrew P. Davison, Joël Chavas and Elodie Legoué
 
 doctest_global_setup = """
 from lazyarray import larray
-import numpy
+import numpy as np
 """

--- a/lazyarray.py
+++ b/lazyarray.py
@@ -13,7 +13,7 @@ import collections
 from functools import wraps, reduce
 import logging
 
-import numpy
+import numpy as np
 try:
     from scipy import sparse
     from scipy.sparse import bsr_matrix, coo_matrix, csc_matrix, csr_matrix, dia_matrix, dok_matrix, lil_matrix
@@ -34,7 +34,7 @@ def check_shape(meth):
     """
     @wraps(meth)
     def wrapped_meth(self, val):
-        if isinstance(val, (larray, numpy.ndarray)) and val.shape:
+        if isinstance(val, (larray, np.ndarray)) and val.shape:
             if val.shape != self._shape:
                 raise ValueError("shape mismatch: objects cannot be broadcast to a single shape")
         return meth(self, val)
@@ -51,7 +51,7 @@ def requires_shape(meth):
 
 
 def full_address(addr, full_shape):
-    if not (isinstance(addr, numpy.ndarray) and addr.dtype == bool and addr.ndim == len(full_shape)):
+    if not (isinstance(addr, np.ndarray) and addr.dtype == bool and addr.ndim == len(full_shape)):
         if not isinstance(addr, tuple):
             addr = (addr,)
         if len(addr) < len(full_shape):
@@ -67,7 +67,7 @@ def partial_shape(addr, full_shape):
     Calculate the size of the sub-array represented by `addr`
     """
     def size(x, max):
-        if isinstance(x, (int, numpy.integer)):
+        if isinstance(x, (int, np.integer)):
             return None
         elif isinstance(x, slice):
             y = min(max, x.stop or max)  # slice limits can go past the bounds
@@ -81,7 +81,7 @@ def partial_shape(addr, full_shape):
             raise TypeError("Unsupported index type %s" % type(x))
 
     addr = full_address(addr, full_shape)
-    if isinstance(addr, numpy.ndarray) and addr.dtype == bool:
+    if isinstance(addr, np.ndarray) and addr.dtype == bool:
         return (addr.sum(),)
     elif all(isinstance(x, collections.Sized) for x in addr):
         return (len(addr[0]),)
@@ -128,6 +128,25 @@ def lazy_unary_operation(name):
     return op
 
 
+def is_array_like(value):
+    # False for numbers, generators, functions, iterators
+    if not isinstance(value, collections.Sized):
+        return False
+    if sparse.issparse(value):
+        return True
+    if isinstance(value, collections.Mapping):
+        # because we may wish to have lazy arrays in which each
+        # item is a dict, for example
+        return False
+    if getattr(value, "is_lazyarray_scalar", False):
+        # for user-defined classes that are "Sized" but that should
+        # be treated as individual elements in a lazy array
+        # the attribute "is_lazyarray_scalar" can be defined with value
+        # True.
+        return False
+    return True
+
+
 
 class larray(object):
     """
@@ -170,13 +189,13 @@ class larray(object):
             self.dtype = dtype or value.dtype
             self.operations = value.operations  # should deepcopy?
 
-        elif isinstance(value, collections.Sized):  # False for numbers, generators, functions, iterators
+        elif is_array_like(value):  # False for numbers, generators, functions, iterators
             if have_scipy and sparse.issparse(value):  # For sparse matrices
                 self.dtype = dtype or value.dtype
-            elif not isinstance(value, numpy.ndarray):
-                value = numpy.array(value, dtype=dtype)
+            elif not isinstance(value, np.ndarray):
+                value = np.array(value, dtype=dtype)
             elif dtype is not None:
-               assert numpy.can_cast(value.dtype, dtype, casting='safe')  # or could convert value to the provided dtype
+               assert np.can_cast(value.dtype, dtype, casting='safe')  # or could convert value to the provided dtype
             if shape and value.shape and value.shape != shape:
                 raise ValueError("Array has shape %s, value has shape %s" % (shape, value.shape))
             if value.shape:
@@ -186,7 +205,7 @@ class larray(object):
             self.base_value = value
 
         else:
-            assert numpy.isreal(value)  # also True for callables, generators, iterators
+            assert np.isreal(value)  # also True for callables, generators, iterators
             self._shape = shape
             if dtype is None or isinstance(value, dtype):
                 self.base_value = value
@@ -203,7 +222,7 @@ class larray(object):
             if len(self.operations) == 0:
                 if isinstance(self.base_value, numbers.Number):
                     return self.base_value == other
-                elif isinstance(self.base_value, numpy.ndarray):
+                elif isinstance(self.base_value, np.ndarray):
                     return (self.base_value == other).all()
             # todo: we could perform the evaluation ourselves, but that could have a performance hit
             raise Exception("You will need to evaluate this lazyarray before checking for equality")
@@ -224,7 +243,7 @@ class larray(object):
         obj.dtype = self.dtype
         obj.operations = []
         for f, arg in self.operations:
-            if isinstance(f, numpy.ufunc):
+            if isinstance(f, np.ufunc):
                 obj.operations.append((f, deepcopy(arg)))
             else:
                 obj.operations.append((deepcopy(f), deepcopy(arg)))
@@ -238,7 +257,7 @@ class larray(object):
 
     def _set_shape(self, value):
         if (hasattr(self.base_value, "shape") and
-                self.base_value.shape and   # values of type numpy.float have an empty shape
+                self.base_value.shape and   # values of type np.float have an empty shape
                     self.base_value.shape != value):
             raise ValueError("Lazy array has fixed shape %s, cannot be changed to %s" % (self.base_value.shape, value))
         self._shape = value
@@ -272,7 +291,7 @@ class larray(object):
     @property
     def is_homogeneous(self):
         """True if all the elements of the array are the same."""
-        hom_base = isinstance(self.base_value, (int, numpy.integer, float, bool)) \
+        hom_base = isinstance(self.base_value, (int, np.integer, float, bool)) \
                    or type(self.base_value) == self.dtype \
                    or (isinstance(self.dtype, type) and isinstance(self.base_value, self.dtype))
         hom_ops = all(obj.is_homogeneous for f, obj in self.operations if isinstance(obj, larray))
@@ -287,7 +306,7 @@ class larray(object):
     def _homogeneous_array(self, addr):
         self.check_bounds(addr)
         shape = self._partial_shape(addr)
-        return numpy.ones(shape, type(self.base_value))
+        return np.ones(shape, type(self.base_value))
 
     def _full_address(self, addr):
         return full_address(addr, self._shape)
@@ -296,28 +315,28 @@ class larray(object):
         self.check_bounds(addr)
 
         def axis_indices(x, max):
-            if isinstance(x, (int, numpy.integer)):
+            if isinstance(x, (int, np.integer)):
                 return x
             elif isinstance(x, slice):  # need to handle negative values in slice
-                return numpy.arange((x.start or 0),
+                return np.arange((x.start or 0),
                                     (x.stop or max),
                                     (x.step or 1),
                                     dtype=int)
             elif isinstance(x, collections.Sized):
                 if hasattr(x, 'dtype') and x.dtype == bool:
-                    return numpy.arange(max)[x]
+                    return np.arange(max)[x]
                 else:
-                    return numpy.array(x)
+                    return np.array(x)
             else:
                 raise TypeError("Unsupported index type %s" % type(x))
         addr = self._full_address(addr)
-        if isinstance(addr, numpy.ndarray) and addr.dtype == bool:
+        if isinstance(addr, np.ndarray) and addr.dtype == bool:
             if addr.ndim == 1:
-                return (numpy.arange(self._shape[0])[addr],)
+                return (np.arange(self._shape[0])[addr],)
             else:
                 raise NotImplementedError()
         elif all(isinstance(x, collections.Sized) for x in addr):
-            indices = [numpy.array(x) for x in addr]
+            indices = [np.array(x) for x in addr]
             return indices
         else:
             indices = [axis_indices(x, max) for (x, max) in zip(addr, self._shape)]
@@ -326,7 +345,7 @@ class larray(object):
             elif len(indices) == 2:
                 if isinstance(indices[0], collections.Sized):
                     if isinstance(indices[1], collections.Sized):
-                        mesh_xy = numpy.meshgrid(*indices)
+                        mesh_xy = np.meshgrid(*indices)
                         return (mesh_xy[0].T, mesh_xy[1].T)  # meshgrid works on (x,y), not (i,j)
                 return indices
             else:
@@ -351,16 +370,16 @@ class larray(object):
                 base_val = self.base_value
             else:
                 base_val = self._homogeneous_array(addr) * self.base_value
-        elif isinstance(self.base_value, (int, numpy.integer, float, bool)):
+        elif isinstance(self.base_value, (int, np.integer, float, bool)):
             base_val = self._homogeneous_array(addr) * self.base_value
-        elif isinstance(self.base_value, numpy.ndarray):
+        elif isinstance(self.base_value, np.ndarray):
             base_val = self.base_value[addr]
         elif have_scipy and sparse.issparse(self.base_value):  # For sparse matrices larr[2, :]
             base_val = self.base_value[addr]
         elif callable(self.base_value):
             indices = self._array_indices(addr)
             base_val = self.base_value(*indices)
-            if isinstance(base_val, numpy.ndarray) and base_val.shape == (1,):
+            if isinstance(base_val, np.ndarray) and base_val.shape == (1,):
                 base_val = base_val[0]
         elif hasattr(self.base_value, "lazily_evaluate"):
             base_val = self.base_value.lazily_evaluate(addr, shape=self._shape)
@@ -390,7 +409,7 @@ class larray(object):
             return hasattr(arr, 'dtype') and arr.dtype == bool
 
         def check_axis(x, size):
-            if isinstance(x, (int, numpy.integer)):
+            if isinstance(x, (int, np.integer)):
                 lower = upper = x
             elif isinstance(x, slice):
                 lower = x.start or 0
@@ -415,7 +434,7 @@ class larray(object):
             if (lower < -size) or (upper >= size):
                 raise IndexError("Index out of bounds")
         full_addr = self._full_address(addr)
-        if isinstance(addr, numpy.ndarray) and addr.dtype == bool:
+        if isinstance(addr, np.ndarray) and addr.dtype == bool:
             if len(addr.shape) > len(self._shape):
                 raise IndexError("Too many indices for array")
             for xmax, size in zip(addr.shape, self._shape):
@@ -432,7 +451,7 @@ class larray(object):
         where `x` will be a scalar or a numpy array.
 
         >>> m = larray(4, shape=(2,2))
-        >>> m.apply(numpy.sqrt)
+        >>> m.apply(np.sqrt)
         >>> m.evaluate()
         array([[ 2.,  2.],
                [ 2.,  2.]])
@@ -466,13 +485,13 @@ class larray(object):
             if simplify:
                 x = self.base_value
             else:
-                x = self.base_value * numpy.ones(self._shape, dtype=self.dtype)
-        elif isinstance(self.base_value, (int, numpy.integer, float, bool, numpy.bool_)):
-            x = self.base_value * numpy.ones(self._shape, dtype=self.dtype)
-        elif isinstance(self.base_value, numpy.ndarray):
+                x = self.base_value * np.ones(self._shape, dtype=self.dtype)
+        elif isinstance(self.base_value, (int, np.integer, float, bool, np.bool_)):
+            x = self.base_value * np.ones(self._shape, dtype=self.dtype)
+        elif isinstance(self.base_value, np.ndarray):
             x = self.base_value
         elif callable(self.base_value):
-            x = numpy.array(numpy.fromfunction(self.base_value, shape=self._shape, dtype=int), dtype=self.dtype)
+            x = np.array(np.fromfunction(self.base_value, shape=self._shape, dtype=int), dtype=self.dtype)
         elif hasattr(self.base_value, "lazily_evaluate"):
             x = self.base_value.lazily_evaluate(shape=self._shape)
         elif isinstance(self.base_value, VectorizedIterable):
@@ -482,11 +501,11 @@ class larray(object):
         elif have_scipy and sparse.issparse(self.base_value):  # For sparse matrices
             if empty_val!=0:
                 x = self.base_value.toarray((sparse.csc_matrix))
-                x = numpy.where(x, x, numpy.nan)
+                x = np.where(x, x, np.nan)
             else:
                 x = self.base_value.toarray((sparse.csc_matrix))
         elif isinstance(self.base_value, collections.Iterator):
-            x = numpy.fromiter(self.base_value, dtype=self.dtype or float, count=self.size)
+            x = np.fromiter(self.base_value, dtype=self.dtype or float, count=self.size)
             if x.shape != self._shape:
                 x = x.reshape(self._shape)
         else:
@@ -558,7 +577,7 @@ class VectorizedIterable(object):
 
 # build lazy-array compatible versions of NumPy ufuncs
 namespace = globals()
-for name in dir(numpy):
-    obj = getattr(numpy, name)
-    if isinstance(obj, numpy.ufunc):
+for name in dir(np):
+    obj = getattr(np, name)
+    if isinstance(obj, np.ufunc):
         namespace[name] = _build_ufunc(obj)

--- a/test/test_lazy_arrays_from_Sparse_Matrices.py
+++ b/test/test_lazy_arrays_from_Sparse_Matrices.py
@@ -1,6 +1,6 @@
-# Support creating lazy arrays from SciPy sparse matrices 
+# Support creating lazy arrays from SciPy sparse matrices
 #
-# 1 program for the 7 sparse matrices classes : 
+# 1 program for the 7 sparse matrices classes :
 #
 # csc_matrix(arg1[, shape, dtype, copy])	            Compressed Sparse Column matrix
 # csr_matrix(arg1[, shape, dtype, copy])	            Compressed Sparse Row matrix
@@ -14,7 +14,7 @@
 
 import numpy as np
 from lazyarray import larray
-from scipy import sparse 
+from scipy import sparse
 import random
 
 
@@ -52,14 +52,14 @@ r = random.randint(-100, 100)
 #print "n =", n
 #print "p =", p
 #print "q  =", q
-#print "r =", r    
+#print "r =", r
 
 
 ##############################################################
 # Definition of an array
 ##############################################################
 
-def test_function_array_general():  
+def test_function_array_general():
     A = np.array([[i, j, k], [l, m, n], [p, q, r]])
     #print "A ="
     #print A
@@ -112,9 +112,9 @@ def sparse_dia_matrices():
     #print dia
     return dia
 
-    
 
-if __name__ == "__main__": 
+
+if __name__ == "__main__":
 
 
 ##############################################################
@@ -124,10 +124,10 @@ if __name__ == "__main__":
 ##############################################################
 
     #print "Array general ="
-    test_function_array_general()    
+    test_function_array_general()
     #print "Array ="
     #print test_function_array_general()
-    
+
 #    print "----"
 
 #    print "Sparse array csc general ="
@@ -174,18 +174,18 @@ if __name__ == "__main__":
 
 
 #print "----------------------------------------------------------------------"
- 
+
 
  ##############################################################
  # Call the sparse matrices
  # Create a lazy array from sparse matrices
  ##############################################################
- 
- 
+
+
 Array_csc_matrices = sparse_csc_matrices().toarray()
 #print "Array csc matrices ="
 #print Array_csc_matrices
-  
+
 Array_csr_matrices = sparse_csr_matrices().toarray()
 #print "Array csr matrices ="
 #print Array_csr_matrices
@@ -197,7 +197,7 @@ Array_bsr_matrices = sparse_bsr_matrices().toarray()
 Array_lil_matrices = sparse_lil_matrices().toarray()
 #print "Array lil matrices ="
 #print Array_lil_matrices
-    
+
 Array_dok_matrices = sparse_dok_matrices().toarray()
 #print "Array dok matrices ="
 #print Array_dok_matrices

--- a/test/test_lazyarray.py
+++ b/test/test_lazyarray.py
@@ -6,7 +6,7 @@ Copyright Andrew P. Davison, Joël Chavas and Elodie Legouée (CNRS), 2012-2020
 """
 
 from lazyarray import larray, VectorizedIterable, sqrt, partial_shape
-import numpy
+import numpy as np
 from nose.tools import assert_raises, assert_equal, assert_not_equal
 from nose import SkipTest
 from numpy.testing import assert_array_equal, assert_array_almost_equal
@@ -25,7 +25,7 @@ class MockRNG(VectorizedIterable):
     def next(self, n):
         s = self.start
         self.start += n * self.delta
-        return s + self.delta * numpy.arange(n)
+        return s + self.delta * np.arange(n)
 
 
 # test larray
@@ -50,19 +50,19 @@ def test_create_with_float():
 def test_create_with_list():
     A = larray([1, 2, 3], shape=(3,))
     assert A.shape == (3,)
-    assert_array_equal(A.evaluate(), numpy.array([1, 2, 3]))
+    assert_array_equal(A.evaluate(), np.array([1, 2, 3]))
 
 
 def test_create_with_array():
-    A = larray(numpy.array([1, 2, 3]), shape=(3,))
+    A = larray(np.array([1, 2, 3]), shape=(3,))
     assert A.shape == (3,)
-    assert_array_equal(A.evaluate(), numpy.array([1, 2, 3]))
+    assert_array_equal(A.evaluate(), np.array([1, 2, 3]))
 
 
 def test_create_with_array_and_dtype():
-    A = larray(numpy.array([1, 2, 3]), shape=(3,), dtype=int)
+    A = larray(np.array([1, 2, 3]), shape=(3,), dtype=int)
     assert A.shape == (3,)
-    assert_array_equal(A.evaluate(), numpy.array([1, 2, 3]))
+    assert_array_equal(A.evaluate(), np.array([1, 2, 3]))
 
 
 def test_create_with_generator():
@@ -73,25 +73,25 @@ def test_create_with_generator():
             i += 1
     A = larray(plusone(), shape=(5, 11))
     assert_array_equal(A.evaluate(),
-                       numpy.arange(55).reshape((5, 11)))
+                       np.arange(55).reshape((5, 11)))
 
 
 def test_create_with_function1D():
     A = larray(lambda i: 99 - i, shape=(3,))
     assert_array_equal(A.evaluate(),
-                       numpy.array([99, 98, 97]))
+                       np.array([99, 98, 97]))
 
 
 def test_create_with_function1D_and_dtype():
     A = larray(lambda i: 99 - i, shape=(3,), dtype=float)
     assert_array_equal(A.evaluate(),
-                       numpy.array([99.0, 98.0, 97.0]))
+                       np.array([99.0, 98.0, 97.0]))
 
 
 def test_create_with_function2D():
     A = larray(lambda i, j: 3 * j - 2 * i, shape=(2, 3))
     assert_array_equal(A.evaluate(),
-                       numpy.array([[0, 3, 6],
+                       np.array([[0, 3, 6],
                                     [-2, 1, 4]]))
 
 
@@ -107,20 +107,20 @@ def test_create_with_larray():
     A = 3 + larray(lambda i: 99 - i, shape=(3,))
     B = larray(A, shape=(3,), dtype=int)
     assert_array_equal(B.evaluate(),
-                       numpy.array([102, 101, 100]))
+                       np.array([102, 101, 100]))
 
 
 ## For sparse matrices
 def test_create_with_sparse_array():
-    row = numpy.array([0, 2, 2, 0, 1, 2])
-    col = numpy.array([0, 0, 1, 2, 2, 2])
-    data = numpy.array([1, 2, 3, 4, 5, 6])
+    row = np.array([0, 2, 2, 0, 1, 2])
+    col = np.array([0, 0, 1, 2, 2, 2])
+    data = np.array([1, 2, 3, 4, 5, 6])
     bsr = larray(bsr_matrix((data, (row, col)), shape=(3, 3))) # For bsr_matrix
     coo = larray(coo_matrix((data, (row, col)), shape=(3, 3))) # For coo_matrix
     csc = larray(csc_matrix((data, (row, col)), shape=(3, 3))) # For csc_matrix
     csr = larray(csr_matrix((data, (row, col)), shape=(3, 3))) # For csr_matrix
-    data_dia = numpy.array([[1, 2, 3, 4]]).repeat(3, axis=0) # For dia_matrix
-    offsets_dia = numpy.array([0, -1, 2]) # For dia_matrix
+    data_dia = np.array([[1, 2, 3, 4]]).repeat(3, axis=0) # For dia_matrix
+    offsets_dia = np.array([0, -1, 2]) # For dia_matrix
     dia = larray(dia_matrix((data_dia, offsets_dia), shape=(4, 4))) # For dia_matrix
     dok = larray(dok_matrix(((row, col)), shape=(3, 3))) # For dok_matrix
     lil = larray(lil_matrix(data, shape=(3, 3))) # For lil_matrix
@@ -195,7 +195,7 @@ def test_create_with_sparse_array():
 #    assert_equal(cols, [5, 5, 5])
 #
 # def test_columnwise_iteration_with_structured_array():
-#    input = numpy.arange(12).reshape((4,3))
+#    input = np.arange(12).reshape((4,3))
 # m = larray(input, shape=(4,3)) # 4 rows, 3 columns
 #    cols = [col for col in m.by_column()]
 #    assert_array_equal(cols[0], input[:,0])
@@ -205,20 +205,20 @@ def test_create_with_sparse_array():
 #    input = lambda i,j: 2*i + j
 #    m = larray(input, shape=(4,3))
 #    cols = [col for col in m.by_column()]
-#    assert_array_equal(cols[0], numpy.array([0, 2, 4, 6]))
-#    assert_array_equal(cols[1], numpy.array([1, 3, 5, 7]))
-#    assert_array_equal(cols[2], numpy.array([2, 4, 6, 8]))
+#    assert_array_equal(cols[0], np.array([0, 2, 4, 6]))
+#    assert_array_equal(cols[1], np.array([1, 3, 5, 7]))
+#    assert_array_equal(cols[2], np.array([2, 4, 6, 8]))
 #
 # def test_columnwise_iteration_with_flat_array_and_mask():
 # m = larray(5, shape=(4,3)) # 4 rows, 3 columns
-#    mask = numpy.array([True, False, True])
+#    mask = np.array([True, False, True])
 #    cols = [col for col in m.by_column(mask=mask)]
 #    assert_equal(cols, [5, 5])
 #
 # def test_columnwise_iteration_with_structured_array_and_mask():
-#    input = numpy.arange(12).reshape((4,3))
+#    input = np.arange(12).reshape((4,3))
 # m = larray(input, shape=(4,3)) # 4 rows, 3 columns
-#    mask = numpy.array([False, True, True])
+#    mask = np.array([False, True, True])
 #    cols = [col for col in m.by_column(mask=mask)]
 #    assert_array_equal(cols[0], input[:,1])
 #    assert_array_equal(cols[1], input[:,2])
@@ -241,11 +241,11 @@ def test_size_related_properties():
 
 def test_evaluate_with_flat_array():
     m = larray(5, shape=(4, 3))
-    assert_array_equal(m.evaluate(), 5 * numpy.ones((4, 3)))
+    assert_array_equal(m.evaluate(), 5 * np.ones((4, 3)))
 
 
 def test_evaluate_with_structured_array():
-    input = numpy.arange(12).reshape((4, 3))
+    input = np.arange(12).reshape((4, 3))
     m = larray(input, shape=(4, 3))
     assert_array_equal(m.evaluate(), input)
 
@@ -254,7 +254,7 @@ def test_evaluate_with_functional_array():
     input = lambda i, j: 2 * i + j
     m = larray(input, shape=(4, 3))
     assert_array_equal(m.evaluate(),
-                       numpy.array([[0, 1, 2],
+                       np.array([[0, 1, 2],
                                     [2, 3, 4],
                                     [4, 5, 6],
                                     [6, 7, 8]]))
@@ -264,7 +264,7 @@ def test_evaluate_with_vectorized_iterable():
     input = MockRNG(0, 1)
     m = larray(input, shape=(7, 3))
     assert_array_equal(m.evaluate(),
-                       numpy.arange(21).reshape((7, 3)))
+                       np.arange(21).reshape((7, 3)))
 
 
 def test_evaluate_twice_with_vectorized_iterable():
@@ -272,9 +272,9 @@ def test_evaluate_twice_with_vectorized_iterable():
     m1 = larray(input, shape=(7, 3)) + 3
     m2 = larray(input, shape=(7, 3)) + 17
     assert_array_equal(m1.evaluate(),
-                       numpy.arange(3, 24).reshape((7, 3)))
+                       np.arange(3, 24).reshape((7, 3)))
     assert_array_equal(m2.evaluate(),
-                       numpy.arange(38, 59).reshape((7, 3)))
+                       np.arange(38, 59).reshape((7, 3)))
 
 
 def test_evaluate_structured_array_size_1_simplify():
@@ -287,7 +287,7 @@ def test_evaluate_structured_array_size_1_simplify():
 def test_iadd_with_flat_array():
     m = larray(5, shape=(4, 3))
     m += 2
-    assert_array_equal(m.evaluate(), 7 * numpy.ones((4, 3)))
+    assert_array_equal(m.evaluate(), 7 * np.ones((4, 3)))
     assert_equal(m.base_value, 5)
     assert_equal(m.evaluate(simplify=True), 7)
 
@@ -307,43 +307,43 @@ def test_lt_with_flat_array():
 
 
 def test_lt_with_structured_array():
-    input = numpy.arange(12).reshape((4, 3))
+    input = np.arange(12).reshape((4, 3))
     m0 = larray(input, shape=(4, 3))
     m1 = m0 < 5
     assert_array_equal(m1.evaluate(simplify=True), input < 5)
 
 
 def test_structured_array_lt_array():
-    input = numpy.arange(12).reshape((4, 3))
+    input = np.arange(12).reshape((4, 3))
     m0 = larray(input, shape=(4, 3))
-    comparison = 5 * numpy.ones((4, 3))
+    comparison = 5 * np.ones((4, 3))
     m1 = m0 < comparison
     assert_array_equal(m1.evaluate(simplify=True), input < comparison)
 
 
 def test_rsub_with_structured_array():
-    m = larray(numpy.arange(12).reshape((4, 3)))
+    m = larray(np.arange(12).reshape((4, 3)))
     assert_array_equal((11 - m).evaluate(),
-                       numpy.arange(11, -1, -1).reshape((4, 3)))
+                       np.arange(11, -1, -1).reshape((4, 3)))
 
 
 def test_inplace_mul_with_structured_array():
     m = larray((3 * x for x in range(4)), shape=(4,))
     m *= 7
     assert_array_equal(m.evaluate(),
-                       numpy.arange(0, 84, 21))
+                       np.arange(0, 84, 21))
 
 
 def test_abs_with_structured_array():
     m = larray(lambda i, j: i - j, shape=(3, 4))
     assert_array_equal(abs(m).evaluate(),
-                       numpy.array([[0, 1, 2, 3],
+                       np.array([[0, 1, 2, 3],
                                     [1, 0, 1, 2],
                                     [2, 1, 0, 1]]))
 
 
 def test_multiple_operations_with_structured_array():
-    input = numpy.arange(12).reshape((4, 3))
+    input = np.arange(12).reshape((4, 3))
     m0 = larray(input, shape=(4, 3))
     m1 = (m0 + 2) < 5
     m2 = (m0 < 5) + 2
@@ -356,16 +356,16 @@ def test_multiple_operations_with_functional_array():
     m = larray(lambda i: i, shape=(5,))
     m0 = m / 100.0
     m1 = 0.2 + m0
-    assert_array_almost_equal(m0.evaluate(), numpy.array([0.0, 0.01, 0.02, 0.03, 0.04]), decimal=12)
-    assert_array_almost_equal(m1.evaluate(), numpy.array([0.20, 0.21, 0.22, 0.23, 0.24]), decimal=12)
+    assert_array_almost_equal(m0.evaluate(), np.array([0.0, 0.01, 0.02, 0.03, 0.04]), decimal=12)
+    assert_array_almost_equal(m1.evaluate(), np.array([0.20, 0.21, 0.22, 0.23, 0.24]), decimal=12)
     assert_equal(m1[0], 0.2)
 
 
 def test_operations_combining_constant_and_structured_arrays():
     m0 = larray(10, shape=(5,))
-    m1 = larray(numpy.arange(5))
+    m1 = larray(np.arange(5))
     m2 = m0 + m1
-    assert_array_almost_equal(m2.evaluate(), numpy.arange(10, 15))
+    assert_array_almost_equal(m2.evaluate(), np.arange(10, 15))
 
 
 def test_apply_function_to_constant_array():
@@ -381,7 +381,7 @@ def test_apply_function_to_constant_array():
 
 def test_apply_function_to_structured_array():
     f = lambda m: 2 * m + 3
-    input = numpy.arange(12).reshape((4, 3))
+    input = np.arange(12).reshape((4, 3))
     m0 = larray(input, shape=(4, 3))
     m1 = f(m0)
     assert isinstance(m1, larray)
@@ -394,7 +394,7 @@ def test_apply_function_to_functional_array():
     f = lambda m: 2 * m + 3
     m1 = f(m0)
     assert_array_equal(m1.evaluate(),
-                       numpy.array([[3, 5, 7],
+                       np.array([[3, 5, 7],
                                     [7, 9, 11],
                                     [11, 13, 15],
                                     [15, 17, 19]]))
@@ -432,7 +432,7 @@ def test_getitem_from_1D_constant_array():
 def test_getitem__with_slice_from_constant_array():
     m = larray(3, shape=(4, 3))
     assert_array_equal(m[:3, 0],
-                       numpy.array([3, 3, 3]))
+                       np.array([3, 3, 3]))
 
 
 def test_getitem__with_thinslice_from_constant_array():
@@ -443,31 +443,31 @@ def test_getitem__with_thinslice_from_constant_array():
 def test_getitem__with_mask_from_constant_array():
     m = larray(3, shape=(4, 3))
     assert_array_equal(m[1, (0, 2)],
-                       numpy.array([3, 3]))
+                       np.array([3, 3]))
 
 
 def test_getitem_with_numpy_integers_from_2D_constant_array():
-    if not hasattr(numpy, "int64"):
+    if not hasattr(np, "int64"):
         raise SkipTest("test requires a 64-bit system")
     m = larray(3, shape=(4, 3))
-    assert m[numpy.int64(0), numpy.int32(0)] == 3
+    assert m[np.int64(0), np.int32(0)] == 3
 
 
 def test_getslice_from_constant_array():
     m = larray(3, shape=(4, 3))
     assert_array_equal(m[:2],
-                       numpy.array([[3, 3, 3],
+                       np.array([[3, 3, 3],
                                     [3, 3, 3]]))
 
 
 def test_getslice_past_bounds_from_constant_array():
     m = larray(3, shape=(5,))
     assert_array_equal(m[2:10],
-                       numpy.array([3, 3, 3]))
+                       np.array([3, 3, 3]))
 
 
 def test_getitem_from_structured_array():
-    m = larray(3 * numpy.ones((4, 3)), shape=(4, 3))
+    m = larray(3 * np.ones((4, 3)), shape=(4, 3))
     assert m[0, 0] == m[3, 2] == m[-1, 2] == m[-4, 2] == m[2, -3] == 3
     assert_raises(IndexError, m.__getitem__, (4, 0))
     assert_raises(IndexError, m.__getitem__, (2, -4))
@@ -492,7 +492,7 @@ def test_getitem_from_vectorized_iterable():
     input = MockRNG(0, 1)
     m = larray(input, shape=(7,))
     m3 = m[3]
-    assert isinstance(m3, (int, numpy.integer))
+    assert isinstance(m3, (int, np.integer))
     assert_equal(m3, 0)
     assert_equal(m[0], 1)
 
@@ -500,7 +500,7 @@ def test_getitem_from_vectorized_iterable():
 def test_getitem_with_slice_from_2D_functional_array():
     m = larray(lambda i, j: 2 * i + j, shape=(6, 5))
     assert_array_equal(m[2:5, 3:],
-                       numpy.array([[7, 8],
+                       np.array([[7, 8],
                                     [9, 10],
                                     [11, 12]]))
 
@@ -510,34 +510,34 @@ def test_getitem_with_slice_from_2D_functional_array_2():
         return i * i + 2 * i * j + 3
     m = larray(test_function, shape=(3, 15))
     assert_array_equal(m[:, 3:14:3],
-                       numpy.fromfunction(test_function, shape=(3, 15))[:, 3:14:3])
+                       np.fromfunction(test_function, shape=(3, 15))[:, 3:14:3])
 
 
 def test_getitem_with_mask_from_2D_functional_array():
-    a = numpy.arange(30).reshape((6, 5))
+    a = np.arange(30).reshape((6, 5))
     m = larray(lambda i, j: 5 * i + j, shape=(6, 5))
     assert_array_equal(a[[2, 3], [3, 4]],
-                       numpy.array([13, 19]))
+                       np.array([13, 19]))
     assert_array_equal(m[[2, 3], [3, 4]],
-                       numpy.array([13, 19]))
+                       np.array([13, 19]))
 
 
 def test_getitem_with_mask_from_1D_functional_array():
-    m = larray(lambda i: numpy.sqrt(i), shape=(10,))
+    m = larray(lambda i: np.sqrt(i), shape=(10,))
     assert_array_equal(m[[0, 1, 4, 9]],
-                       numpy.array([0, 1, 2, 3]))
+                       np.array([0, 1, 2, 3]))
 
 
 def test_getitem_with_boolean_mask_from_1D_functional_array():
-    m = larray(lambda i: numpy.sqrt(i), shape=(10,))
-    assert_array_equal(m[numpy.array([1, 1, 0, 0, 1, 0, 0, 0, 0, 1], dtype=bool)],
-                       numpy.array([0, 1, 2, 3]))
+    m = larray(lambda i: np.sqrt(i), shape=(10,))
+    assert_array_equal(m[np.array([1, 1, 0, 0, 1, 0, 0, 0, 0, 1], dtype=bool)],
+                       np.array([0, 1, 2, 3]))
 
 
 def test_getslice_from_2D_functional_array():
     m = larray(lambda i, j: 2 * i + j, shape=(6, 5))
     assert_array_equal(m[1:3],
-                       numpy.array([[2, 3, 4, 5, 6],
+                       np.array([[2, 3, 4, 5, 6],
                                     [4, 5, 6, 7, 8]]))
 
 
@@ -547,10 +547,10 @@ def test_getitem_from_iterator_array():
 
 
 def test_getitem_from_array_with_operations():
-    a1 = numpy.array([[1, 3, 5], [7, 9, 11]])
+    a1 = np.array([[1, 3, 5], [7, 9, 11]])
     m1 = larray(a1)
-    f = lambda i, j: numpy.sqrt(i * i + j * j)
-    a2 = numpy.fromfunction(f, shape=(2, 3))
+    f = lambda i, j: np.sqrt(i * i + j * j)
+    a2 = np.fromfunction(f, shape=(2, 3))
     m2 = larray(f, shape=(2, 3))
     a3 = 3 * a1 + a2
     m3 = 3 * m1 + m2
@@ -582,11 +582,11 @@ def test_check_bounds_with_invalid_address2():
 
 def test_partially_evaluate_constant_array_with_one_element():
     m = larray(3, shape=(1,))
-    a = 3 * numpy.ones((1,))
+    a = 3 * np.ones((1,))
     m1 = larray(3, shape=(1, 1))
-    a1 = 3 * numpy.ones((1, 1))
+    a1 = 3 * np.ones((1, 1))
     m2 = larray(3, shape=(1, 1, 1))
-    a2 = 3 * numpy.ones((1, 1, 1))
+    a2 = 3 * np.ones((1, 1, 1))
     assert_equal(a[0], m[0])
     assert_equal(a.shape, m.shape)
     assert_equal(a[:].shape, m[:].shape)
@@ -603,9 +603,9 @@ def test_partially_evaluate_constant_array_with_one_element():
 
 def test_partially_evaluate_constant_array_with_boolean_index():
     m = larray(3, shape=(4, 5))
-    a = 3 * numpy.ones((4, 5))
-    addr_bool = numpy.array([True, True, False, False, True])
-    addr_int = numpy.array([0, 1, 4])
+    a = 3 * np.ones((4, 5))
+    addr_bool = np.array([True, True, False, False, True])
+    addr_int = np.array([0, 1, 4])
     assert_equal(a[::2, addr_bool].shape, a[::2, addr_int].shape)
     assert_equal(a[::2, addr_int].shape, m[::2, addr_int].shape)
     assert_equal(a[::2, addr_bool].shape, m[::2, addr_bool].shape)
@@ -613,37 +613,37 @@ def test_partially_evaluate_constant_array_with_boolean_index():
 
 def test_partially_evaluate_constant_array_with_all_boolean_indices_false():
     m = larray(3, shape=(3,))
-    a = 3 * numpy.ones((3,))
-    addr_bool = numpy.array([False, False, False])
+    a = 3 * np.ones((3,))
+    addr_bool = np.array([False, False, False])
     assert_equal(a[addr_bool].shape, m[addr_bool].shape)
 
 
 def test_partially_evaluate_constant_array_with_only_one_boolean_indice_true():
     m = larray(3, shape=(3,))
-    a = 3 * numpy.ones((3,))
-    addr_bool = numpy.array([False, True, False])
+    a = 3 * np.ones((3,))
+    addr_bool = np.array([False, True, False])
     assert_equal(a[addr_bool].shape, m[addr_bool].shape)
     assert_equal(m[addr_bool][0], a[0])
 
 
 def test_partially_evaluate_constant_array_with_boolean_indice_as_random_valid_ndarray():
     m = larray(3, shape=(3,))
-    a = 3 * numpy.ones((3,))
-    addr_bool = numpy.random.rand(3) > 0.5
+    a = 3 * np.ones((3,))
+    addr_bool = np.random.rand(3) > 0.5
     while not addr_bool.any():
         # random array, but not [False, False, False]
-        addr_bool = numpy.random.rand(3) > 0.5
+        addr_bool = np.random.rand(3) > 0.5
     assert_equal(a[addr_bool].shape, m[addr_bool].shape)
     assert_equal(m[addr_bool][0], a[addr_bool][0])
 
 
 def test_partially_evaluate_constant_array_size_one_with_boolean_index_true():
     m = larray(3, shape=(1,))
-    a = numpy.array([3])
-    addr_bool = numpy.array([True])
+    a = np.array([3])
+    addr_bool = np.array([True])
     m1 = larray(3, shape=(1, 1))
-    a1 = 3 * numpy.ones((1, 1))
-    addr_bool1 = numpy.array([[True]], ndmin=2)
+    a1 = 3 * np.ones((1, 1))
+    addr_bool1 = np.array([[True]], ndmin=2)
     assert_equal(m[addr_bool][0], a[0])
     assert_equal(m[addr_bool], a[addr_bool])
     assert_equal(m[addr_bool].shape, a[addr_bool].shape)
@@ -653,8 +653,8 @@ def test_partially_evaluate_constant_array_size_one_with_boolean_index_true():
 
 def test_partially_evaluate_constant_array_size_two_with_boolean_index_true():
     m2 = larray(3, shape=(1, 2))
-    a2 = 3 * numpy.ones((1, 2))
-    addr_bool2 = numpy.ones((1, 2), dtype=bool)
+    a2 = 3 * np.ones((1, 2))
+    addr_bool2 = np.ones((1, 2), dtype=bool)
     assert_equal(m2[addr_bool2][0], a2[addr_bool2][0])
     assert_equal(m2[addr_bool2].shape, a2[addr_bool2].shape)
 
@@ -662,28 +662,28 @@ def test_partially_evaluate_constant_array_size_two_with_boolean_index_true():
 def test_partially_evaluate_constant_array_size_one_with_boolean_index_false():
     m = larray(3, shape=(1,))
     m1 = larray(3, shape=(1, 1))
-    a = numpy.array([3])
-    a1 = numpy.array([[3]], ndmin=2)
-    addr_bool = numpy.array([False])
-    addr_bool1 = numpy.array([[False]], ndmin=2)
-    addr_bool2 = numpy.array([False])
+    a = np.array([3])
+    a1 = np.array([[3]], ndmin=2)
+    addr_bool = np.array([False])
+    addr_bool1 = np.array([[False]], ndmin=2)
+    addr_bool2 = np.array([False])
     assert_equal(m[addr_bool].shape, a[addr_bool].shape)
     assert_equal(m1[addr_bool1].shape, a1[addr_bool1].shape)
 
 
 def test_partially_evaluate_constant_array_size_with_empty_boolean_index():
     m = larray(3, shape=(1,))
-    a = numpy.array([3])
-    addr_bool = numpy.array([], dtype='bool')
+    a = np.array([3])
+    addr_bool = np.array([], dtype='bool')
     assert_equal(m[addr_bool].shape, a[addr_bool].shape)
     assert_equal(m[addr_bool].shape, (0,))
 
 
 def test_partially_evaluate_functional_array_with_boolean_index():
     m = larray(lambda i, j: 5 * i + j, shape=(4, 5))
-    a = numpy.arange(20.0).reshape((4, 5))
-    addr_bool = numpy.array([True, True, False, False, True])
-    addr_int = numpy.array([0, 1, 4])
+    a = np.arange(20.0).reshape((4, 5))
+    addr_bool = np.array([True, True, False, False, True])
+    addr_int = np.array([0, 1, 4])
     assert_equal(a[::2, addr_bool].shape, a[::2, addr_int].shape)
     assert_equal(a[::2, addr_int].shape, m[::2, addr_int].shape)
     assert_equal(a[::2, addr_bool].shape, m[::2, addr_bool].shape)
@@ -693,7 +693,7 @@ def test_getslice_with_vectorized_iterable():
     input = MockRNG(0, 1)
     m = larray(input, shape=(7, 3))
     assert_array_equal(m[::2, (0, 2)],
-                       numpy.arange(8).reshape((4, 2)))
+                       np.arange(8).reshape((4, 2)))
 
 
 def test_equality_with_lazyarray():
@@ -715,7 +715,7 @@ def test_equality_with_number():
 
 def test_equality_with_array():
     m1 = larray(42.0, shape=(4, 5))
-    target = 42.0 * numpy.ones((4, 5))
+    target = 42.0 * np.ones((4, 5))
     assert_raises(TypeError, m1.__eq__, target)
 
 
@@ -733,27 +733,27 @@ def test_deepcopy_with_ufunc():
     m1 = sqrt(larray([x ** 2 for x in range(5)]))
     m2 = deepcopy(m1)
     m1.base_value[0] = 49
-    assert_array_equal(m1.evaluate(), numpy.array([7, 1, 2, 3, 4]))
-    assert_array_equal(m2.evaluate(), numpy.array([0, 1, 2, 3, 4]))
+    assert_array_equal(m1.evaluate(), np.array([7, 1, 2, 3, 4]))
+    assert_array_equal(m2.evaluate(), np.array([0, 1, 2, 3, 4]))
 
 
 def test_set_shape():
     m = larray(42) + larray(lambda i: 3 * i)
     assert_equal(m.shape, None)
     m.shape = (5,)
-    assert_array_equal(m.evaluate(), numpy.array([42, 45, 48, 51, 54]))
+    assert_array_equal(m.evaluate(), np.array([42, 45, 48, 51, 54]))
 
 
 def test_call():
-    A = larray(numpy.array([1, 2, 3]), shape=(3,)) - 1
+    A = larray(np.array([1, 2, 3]), shape=(3,)) - 1
     B = 0.5 * larray(lambda i: 2 * i, shape=(3,))
     C = B(A)
-    assert_array_equal(C.evaluate(), numpy.array([0, 1, 2]))
-    assert_array_equal(A.evaluate(), numpy.array([0, 1, 2]))  # A should be unchanged
+    assert_array_equal(C.evaluate(), np.array([0, 1, 2]))
+    assert_array_equal(A.evaluate(), np.array([0, 1, 2]))  # A should be unchanged
 
 
 def test_call2():
-    positions = numpy.array(
+    positions = np.array(
         [[0.,  2.,  4.,  6.,  8.],
          [0.,  0.,  0.,  0.,  0.],
          [0.,  0.,  0.,  0.,  0.]])
@@ -764,8 +764,8 @@ def test_call2():
     def distances(A, B):
         d = A - B
         d **= 2
-        d = numpy.sum(d, axis=-1)
-        numpy.sqrt(d, d)
+        d = np.sum(d, axis=-1)
+        np.sqrt(d, d)
         return d
 
     def distance_generator(f, g):
@@ -777,7 +777,7 @@ def test_call2():
     f_delay = 1000 * larray(lambda d: 0.1 * (1 + d), shape=(4, 5))
     assert_array_almost_equal(
         f_delay(distance_map).evaluate(),
-        numpy.array([[100, 300, 500, 700, 900],
+        np.array([[100, 300, 500, 700, 900],
                      [300, 100, 300, 500, 700],
                      [500, 300, 100, 300, 500],
                      [700, 500, 300, 100, 300]], dtype=float),
@@ -785,7 +785,7 @@ def test_call2():
     # repeat, should be idempotent
     assert_array_almost_equal(
         f_delay(distance_map).evaluate(),
-        numpy.array([[100, 300, 500, 700, 900],
+        np.array([[100, 300, 500, 700, 900],
                      [300, 100, 300, 500, 700],
                      [500, 300, 100, 300, 500],
                      [700, 500, 300, 100, 300]], dtype=float),
@@ -794,16 +794,16 @@ def test_call2():
 
 def test__issue4():
     # In order to avoid the errors associated with version changes of numpy, mask1 and mask2 no longer contain boolean values ​​but integer values
-    a = numpy.arange(12).reshape((4, 3))
-    b = larray(numpy.arange(12).reshape((4, 3)))
+    a = np.arange(12).reshape((4, 3))
+    b = larray(np.arange(12).reshape((4, 3)))
     mask1 = (slice(None), int(True))
-    mask2 = (slice(None), numpy.array([int(True)]))
+    mask2 = (slice(None), np.array([int(True)]))
     assert_equal(b[mask1].shape, partial_shape(mask1, b.shape), a[mask1].shape)
     assert_equal(b[mask2].shape, partial_shape(mask2, b.shape), a[mask2].shape)
 
 
 def test__issue3():
-    a = numpy.arange(12).reshape((4, 3))
+    a = np.arange(12).reshape((4, 3))
     b = larray(a)
     c = larray(lambda i, j: 3*i + j, shape=(4, 3))
     assert_array_equal(a[(1, 3), :][:, (0, 2)], b[(1, 3), :][:, (0, 2)])
@@ -813,7 +813,7 @@ def test__issue3():
 
 
 def test_partial_shape():
-    a = numpy.arange(12).reshape((4, 3))
+    a = np.arange(12).reshape((4, 3))
     test_cases = [
         (slice(None), (4, 3)),
         ((slice(None), slice(None)), (4, 3)),
@@ -821,27 +821,27 @@ def test_partial_shape():
         (1, (3,)),
         ((1, slice(None)), (3,)),
         ([0, 2, 3], (3, 3)),
-        (numpy.array([0, 2, 3]), (3, 3)),
-        ((numpy.array([0, 2, 3]), slice(None)), (3, 3)),
-        (numpy.array([True, False, True, True]), (3, 3)),
-        #(numpy.array([True, False]), (1, 3)),  # not valid with NumPy 1.13
-        (numpy.array([[True, False, False], [False, False, False], [True, True, False], [False, True, False]]), (4,)),
-        #(numpy.array([[True, False, False], [False, False, False], [True, True, False]]), (3,)),  # not valid with NumPy 1.13
+        (np.array([0, 2, 3]), (3, 3)),
+        ((np.array([0, 2, 3]), slice(None)), (3, 3)),
+        (np.array([True, False, True, True]), (3, 3)),
+        #(np.array([True, False]), (1, 3)),  # not valid with NumPy 1.13
+        (np.array([[True, False, False], [False, False, False], [True, True, False], [False, True, False]]), (4,)),
+        #(np.array([[True, False, False], [False, False, False], [True, True, False]]), (3,)),  # not valid with NumPy 1.13
         ((3, 1), tuple()),
         ((slice(None), 1), (4,)),
         ((slice(None), slice(1, None, 3)), (4, 1)),
-        ((numpy.array([0, 3]), 2), (2,)),
-        ((numpy.array([0, 3]), numpy.array([1, 2])), (2,)),
-        ((slice(None), numpy.array([2])), (4, 1)),
+        ((np.array([0, 3]), 2), (2,)),
+        ((np.array([0, 3]), np.array([1, 2])), (2,)),
+        ((slice(None), np.array([2])), (4, 1)),
         (((1, 3), (0, 2)), (2,)),
-        (numpy.array([], bool), (0, 3)),
+        (np.array([], bool), (0, 3)),
     ]
     for mask, expected_shape in test_cases:
         assert_equal(partial_shape(mask, a.shape), a[mask].shape)
         assert_equal(partial_shape(mask, a.shape), expected_shape)
-    b = numpy.arange(5)
+    b = np.arange(5)
     test_cases = [
-        (numpy.arange(5), (5,))
+        (np.arange(5), (5,))
     ]
     for mask, expected_shape in test_cases:
         assert_equal(partial_shape(mask, b.shape), b[mask].shape)
@@ -849,7 +849,7 @@ def test_partial_shape():
 
 def test_is_homogeneous():
     m0 = larray(10, shape=(5,))
-    m1 = larray(numpy.arange(1, 6))
+    m1 = larray(np.arange(1, 6))
     m2 = m0 + m1
     m3 = 9 + m0 / m1
     assert m0.is_homogeneous

--- a/test/test_ufunc.py
+++ b/test/test_ufunc.py
@@ -5,40 +5,40 @@ Copyright Andrew P. Davison, 2012-2017
 """
 
 from lazyarray import larray, sqrt, cos
-import numpy
+import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 
 def test_sqrt_from_array():
-    A = larray(numpy.array([1, 4, 9, 16, 25]))
+    A = larray(np.array([1, 4, 9, 16, 25]))
     assert_array_equal(sqrt(A).evaluate(),
-                       numpy.arange(1, 6))
+                       np.arange(1, 6))
 
 
 def test_sqrt_from_iterator():
     A = larray(iter([1, 4, 9, 16, 25]), shape=(5,))
     assert_array_equal(sqrt(A).evaluate(),
-                       numpy.arange(1, 6))
+                       np.arange(1, 6))
 
 
 def test_sqrt_from_func():
     A = larray(lambda x: (x + 1) ** 2, shape=(5,))
     assert_array_equal(sqrt(A).evaluate(),
-                       numpy.arange(1, 6))
+                       np.arange(1, 6))
 
 
 def test_sqrt_normal_array():
-    A = numpy.array([1, 4, 9, 16, 25])
+    A = np.array([1, 4, 9, 16, 25])
     assert_array_equal(sqrt(A),
-                       numpy.arange(1, 6))
+                       np.arange(1, 6))
 
 
 def test_cos_from_generator():
     def clock():
-        for x in numpy.arange(0, 2 * numpy.pi, numpy.pi / 2):
+        for x in np.arange(0, 2 * np.pi, np.pi / 2):
             yield x
     A = larray(clock(), shape=(2, 2))
     assert_array_almost_equal(cos(A).evaluate(),
-                              numpy.array([[1.0, 0.0],
+                              np.array([[1.0, 0.0],
                                            [-1.0, 0.0]]),
                               decimal=15)


### PR DESCRIPTION
 (for arrays of arrays, etc.)

also switches to using "import numpy as np"
